### PR TITLE
fixes loading state not disabling button

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -55,13 +55,16 @@ export const Button = ({
     icon,
     isFullWidth,
     intent,
+    isDisabled,
     ...props
 }) => {
     if (isLoading) {
         return (
             <button
+                data-loading={isLoading}
+                disabled={isDisabled || isLoading}
                 className={clsx(
-                    { loading: isLoading },
+                    { loading: isLoading, disabled: isDisabled },
                     "mainsail-button",
                     className,
                     variant,
@@ -77,6 +80,7 @@ export const Button = ({
     return (
         <button
             data-loading={isLoading}
+            disabled={isDisabled || isLoading}
             className={clsx(
                 "mainsail-button",
                 className,
@@ -130,7 +134,7 @@ Button.propTypes = {
     /** (Optional) click handler */
     onClick: PropTypes.func,
     /** Disabled state */
-    disabled: PropTypes.bool,
+    isDisabled: PropTypes.bool,
     /** Loading state */
     isLoading: PropTypes.bool,
     /** If true, will cause button to take up full width of parent */

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -259,4 +259,13 @@ button.mainsail-button {
     &.full-width {
         width: 100%;
     }
+
+    &.loading {
+        &:disabled {
+            opacity: 1;
+        }
+        &.disabled {
+            opacity: 0.3;
+        }
+    }
 }

--- a/src/components/Button/Button.test.js
+++ b/src/components/Button/Button.test.js
@@ -85,6 +85,17 @@ it("renders the loading text if in loading state", () => {
     expect(screen.getByRole("button")).toHaveTextContent("Waiting");
 });
 
+it("disables the button if in loading state", () => {
+    let onClick = jest.fn();
+    render(<Loading {...LoadingWithText.args} onClick={onClick} />);
+    expect(screen.getByRole("button")).toHaveTextContent("Waiting");
+
+    userEvent.click(screen.getByRole("button"));
+
+    expect(onClick).toHaveBeenCalledTimes(0);
+    expect(screen.getByRole("button")).toBeDisabled();
+});
+
 it("renders the button in a disabled state", () => {
     render(<Disabled {...Disabled.args} />);
     expect(screen.getByRole("button")).toHaveTextContent("Disabled");


### PR DESCRIPTION
This PR fixes the button state not being disabled (and accepting onClicks) when in loading state