### PR TITLE
adds icon button example to css-only docs

### DIFF
--- a/src/stories/css-components.stories.mdx
+++ b/src/stories/css-components.stories.mdx
@@ -70,6 +70,45 @@ Buttons have variants and intent styles available as sub classes.
     <button class="mainsail-button filtering link">Link Button</button>
 </Canvas>
 
+**With Icon**
+
+> IMPORTANT: When including icons and text in buttons, Mainsail UI requires the text to be wrapped to automatically handle proper margins for icons.
+
+<Canvas>
+    <button class="mainsail-button primary">
+        <span class="mainsail-icon lg dark">
+            <svg
+                width="19"
+                height="32"
+                viewBox="0 0 19 32"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg">
+                <path
+                    id="back"
+                    d="M0.704658 17.0464C0.315288 16.6557 0.315837 16.0235 0.705882 15.6334L16.1299 0.209394C16.1299 0.209394 16.9929 -0.392341 17.8296 0.44431C18.6675 1.28097 17.8296 2.01334 17.8296 2.01334L3.47715 16.3671L17.1501 30.04C17.1501 30.04 17.8611 30.8968 17.0973 31.6605C16.3348 32.4243 15.2682 31.6605 15.2682 31.6605L0.704658 17.0464Z"
+                    fill="currentColor"
+                />
+            </svg>
+        </span>
+        <span>Back</span>
+    </button>
+    <button class="mainsail-button primary">
+        <span>Forward</span>
+        <span class="mainsail-icon lg dark">
+            <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 18 32"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg">
+                <path
+                    d="M17.497 17.046a1 1 0 000-1.413L2.071.21S1.21-.392.372.444c-.837.837 0 1.57 0 1.57l14.353 14.353L1.052 30.04s-.71.857.053 1.62c.762.764 1.829 0 1.829 0l14.563-14.614z"
+                    fill="currentColor"></path>
+            </svg>
+        </span>
+    </button>
+</Canvas>
+
 ## Icons
 
 Icon svg files may be added directly to the html code and have styling and sizing classes ready to go in Mainsail css.


### PR DESCRIPTION
This PR updates the Storybook css-only for the buttons to display an example of how to make an icon button.