### PR TITLE
Modal focus issues

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -80,7 +80,7 @@ export const Button = ({
                     textSize
                 )}
                 {...props}>
-                <Spinner />
+                {!loadingText ? <Spinner /> : null}
                 {loadingText ? renderChild(loadingText) : null}
                 {children}
             </button>

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -52,9 +52,7 @@ button.mainsail-button {
             box-shadow: $mainsail-shadow-active;
         }
 
-        @include focus {
-            outline: none;
-        }
+        @include focus;
 
         @include disabled;
 
@@ -100,10 +98,7 @@ button.mainsail-button {
         @include active {
             box-shadow: $mainsail-shadow-active;
         }
-        @include focus {
-            outline: none;
-        }
-
+        @include focus;
         @include disabled;
 
         &.filtering {
@@ -153,6 +148,8 @@ button.mainsail-button {
 
         @include disabled;
 
+        @include focus;
+
         &.filtering {
             color: $mainsail-green-middle;
             background: none;
@@ -197,9 +194,7 @@ button.mainsail-button {
             text-decoration: underline;
         }
 
-        @include focus {
-            outline-offset: 4px;
-        }
+        @include focus;
 
         @include disabled;
 
@@ -237,18 +232,13 @@ button.mainsail-button {
         color: $mainsail-blue-primary;
         background: none;
         box-shadow: none;
-        &:hover {
+
+        @include focus;
+        @include hover {
+            color: $mainsail-blue-primary;
             background: $mainsail-blue-light;
             border-radius: $mainsail-button-border-radius-lg;
         }
-    }
-
-    &:hover {
-        box-shadow: none;
-    }
-
-    &:focus {
-        outline: 5px auto $mainsail-blue-primary;
     }
 
     &.text-small {

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 import { Button } from "components/Button";
@@ -47,10 +47,41 @@ export const Modal = ({
     const showBackButton = typeof onClickBack === "function";
     const [openClass, setOpenClass] = useState(isOpen ? "open" : "");
     const modalId = useUniqueId("modal");
+    const modalRef = useRef(null);
 
     useKeydown((e) => {
         if (e.charCode === 27 || e.keyCode === 27) {
             handleDismiss();
+        }
+    });
+
+    // Handle focus trap
+    useKeydown((e) => {
+        const focusableElements =
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+        let isTabPressed = e.key === "Tab" || e.keyCode === 9;
+
+        if (!isTabPressed || !modalRef) {
+            return;
+        }
+
+        const focusableContent =
+            modalRef.current &&
+            modalRef.current.querySelectorAll(focusableElements);
+        const firstFocusableElement =
+            modalRef.current &&
+            modalRef.current.querySelectorAll(focusableElements)[0];
+        const lastFocusableElement =
+            focusableContent && focusableContent[focusableContent.length - 1];
+
+        if (e.shiftKey) {
+            if (document.activeElement === firstFocusableElement) {
+                lastFocusableElement.focus();
+                e.preventDefault();
+            }
+        } else if (document.activeElement === lastFocusableElement) {
+            firstFocusableElement.focus();
+            e.preventDefault();
         }
     });
 
@@ -125,6 +156,7 @@ export const Modal = ({
                     }}
                     onExited={handleOnClose}>
                     <div
+                        ref={modalRef}
                         role="dialog"
                         aria-labelledby={`${modalId}-title`}
                         aria-describedby={`${modalId}-desc`}

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -13,6 +13,11 @@ export const intents = {
     danger: "danger",
 };
 
+export const confirmVariants = {
+    [Button.variants.primary]: Button.variants.primary,
+    [Button.variants.secondary]: Button.variants.secondary,
+};
+
 /**
  * @deprecated since version 7.0 - use directly attached ComponentName.<propNames>.value; e.g. Button.variants.secondary
  */
@@ -29,6 +34,7 @@ export const Modal = ({
     onConfirm,
     isLoading,
     confirmText,
+    confirmVariant,
     loadingText,
     onCancel,
     cancelText,
@@ -219,7 +225,7 @@ export const Modal = ({
                                         variant={
                                             intent === intents.danger
                                                 ? Button.variants.primary
-                                                : Button.variants.secondary
+                                                : confirmVariant
                                         }
                                         intent={intent}
                                         text={
@@ -249,6 +255,8 @@ Modal.propTypes = {
     className: PropTypes.string,
     /** The title text of the modal */
     title: PropTypes.string.isRequired,
+    /** The confirm button variant of the modal (if using default footer)*/
+    confirmVariant: PropTypes.oneOf(Object.keys(confirmVariants)),
     /** The confirm button text of the modal (if using default footer)*/
     confirmText: PropTypes.string,
     /** The confirm button text of the modal when confirm clicked (if using default footer)*/
@@ -297,6 +305,7 @@ Modal.propTypes = {
 };
 
 Modal.defaultProps = {
+    confirmVariant: Button.variants.secondary,
     isDismissable: false,
     intent: intents.default,
     hasOverlay: true,
@@ -309,3 +318,4 @@ Modal.defaultProps = {
  * Modal.variants = variants
  */
 Modal.intents = intents;
+Modal.confirmVariants = confirmVariants;

--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -103,7 +103,6 @@ const Template = (args) => {
 
 export const BasicConfirm = Template.bind({});
 BasicConfirm.args = {
-    isOpen: true,
     title: "Confirm",
     isDismissable: false,
     onClickBack: null,

--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -110,20 +110,26 @@ const Template = (args) => {
     );
 };
 
-export const BasicConfirm = Template.bind({});
+export const BasicConfirm = (args) => <Modal {...args} />;
 BasicConfirm.args = {
+    isOpen: true,
     title: "Confirm",
+    maxWidth: "600px",
     isDismissable: false,
     onClickBack: null,
-    onCancel: () => setModalTemplateOpen(false),
-    onConfirm: () => setModalTemplateOpen(false),
     children: (
         <div>
-            <p>
+            <p className="mb-20">
                 The size of the modal is defined by its content or the{" "}
-                <code>maxWidth</code> prop. Modal height and padding is handled
-                for you. If you need to force height, style your content
-                accordingly.
+                <code>maxWidth</code> prop.
+                <br /> Modal height and padding is handled for you. If you need
+                to force height, style your content accordingly.
+            </p>
+
+            <p className="mb-20">
+                This example has no page wrapper or state mangagement. Because
+                of this, you can see the callbacks fire in the{" "}
+                <strong>Actions</strong> tab.
             </p>
         </div>
     ),

--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -8,7 +8,16 @@ import { Transition } from "components/Transition";
 export default {
     title: "Overlay/Modal",
     component: Modal,
-    argTypes: {},
+    argTypes: {
+        confirmVariant: {
+            name: "confirmVariant",
+            type: { confirmVariant: "string" },
+            control: {
+                type: "select",
+            },
+            options: Object.keys(Modal.confirmVariants),
+        },
+    },
 };
 
 let setModalTemplateOpen;

--- a/src/components/Modal/Modal.test.js
+++ b/src/components/Modal/Modal.test.js
@@ -67,7 +67,9 @@ it("can be dismissed by hitting the default cancel", async () => {
 });
 
 it("renders with a default footer in a loading/submission state", () => {
-    render(<BasicConfirm {...BasicConfirm.args} isLoading={true} />);
+    render(
+        <BasicConfirm {...BasicConfirm.args} isOpen={true} isLoading={true} />
+    );
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByTestId("spinner")).toBeInTheDocument();
 });

--- a/src/styles/Utility.scss
+++ b/src/styles/Utility.scss
@@ -103,8 +103,8 @@
 
 @mixin focus {
     &:not([disabled]):not([hover]):focus {
-        outline: 1px solid $mainsail-blue-primary;
-        outline-offset: 2px;
+        outline: none;
+        box-shadow: 0 0 0 2px $mainsail-blue-primary;
         @content;
     }
 }
@@ -112,7 +112,7 @@
 @mixin active {
     &:not([disabled]):not([hover]):active {
         outline: none;
-        outline-offset: 0;
+        box-shadow: 0 0 0 2px $mainsail-blue-primary;
         @content;
     }
 }

--- a/src/utility/hooks.js
+++ b/src/utility/hooks.js
@@ -31,14 +31,14 @@ export const WithPortal = memo(Portal);
 /**
  *  useKeydown - detect keypress and respond via a provided callback
  */
-export const useKeydown = (callback) => {
+export const useKeydown = (callback, deps = []) => {
     useEffect(() => {
         document.body.addEventListener("keydown", callback);
 
         return () => {
             document.body.removeEventListener("keydown", callback);
         };
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    }, deps); // eslint-disable-line react-hooks/exhaustive-deps
 };
 
 /**


### PR DESCRIPTION
- adds focus trap to modal
- improves keydown hook
- improves button focus state styling
- adds confirm button variant control to modal
- releases button loading state text from the shackles of being tied to the spinner (use them independently now)
- improves basic modal story to not utilize an opening animation (for chromatic/simplicity, also enables Actions tab to catch callback activity)