### PR TITLE
fixes another wrongly used mixin for modal

### DIFF
--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -43,7 +43,7 @@
         max-width: 100%;
         min-width: 100%;
 
-        @include sm-size-up {
+        @include md-size-up {
             min-width: 500px;
         }
 


### PR DESCRIPTION
- fixes the space at sides between sm and md when using `isFullScreenMobile`