### PR TITLE
Modal patches

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -277,6 +277,7 @@ export const Modal = ({
                             ) : (
                                 <>
                                     <Button
+                                        className="mr-10"
                                         onClick={onCancel}
                                         variant={Button.variants.tertiary}
                                         text={

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -30,6 +30,7 @@
     }
 
     .mainsail-modal-content {
+        max-height: 80%;
         background-color: $mainsail-white;
         box-shadow: $mainsail-shadow-far;
         border-radius: $mainsail-modal-radius;
@@ -109,10 +110,6 @@
             flex-direction: row;
             align-items: center;
             justify-content: flex-end;
-
-            * + * {
-                margin-left: 10px;
-            }
 
             border-bottom-right-radius: $mainsail-modal-radius;
             border-bottom-left-radius: $mainsail-modal-radius;

--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -201,6 +201,7 @@ ScrollingContent.args = {
     title: "Confirm",
     isDismissable: false,
     onClickBack: null,
+    bodyWidth: ["100%", "600px"],
     onCancel: () => setModalTemplateOpen(false),
     onConfirm: () => setModalTemplateOpen(false),
     children: (
@@ -410,6 +411,7 @@ export const WithCustomFooter = Template.bind({});
 WithCustomFooter.args = {
     title: "Fancy Footwork",
     onClickBack: null,
+    bodyWidth: ["100%", "600px"],
     isDismissable: false,
     onCancel: () => setModalTemplateOpen(false),
     onConfirm: () => setModalTemplateOpen(false),
@@ -427,6 +429,7 @@ WithCustomFooter.args = {
                 <Checkbox text="Keep on" />
             </div>
             <Button
+                className="mr-10"
                 text="I'd rather not..."
                 variant={Button.variants.tertiary}
                 onClick={() => setModalTemplateOpen(false)}
@@ -450,6 +453,7 @@ WithCustomFooter.parameters = {
 
 export const CustomButtonText = Template.bind({});
 CustomButtonText.args = {
+    bodyWidth: ["100%", "600px"],
     onClickBack: null,
     title: "Get to Da Choppa",
     confirmText: "Do it naow!",
@@ -469,6 +473,7 @@ CustomButtonText.args = {
 export const LoadingState = Template.bind({});
 LoadingState.args = {
     onClickBack: null,
+    bodyWidth: ["100%", "600px"],
     title: "Confirm",
     confirmText: "Submit",
     loadingText: "Submitting",

--- a/src/styles/Layout.scss
+++ b/src/styles/Layout.scss
@@ -38,6 +38,17 @@
     @include spacing-modifiers($attribute: "margin-left");
 }
 
+.mr-auto {
+    margin-right: auto !important;
+}
+.ml-auto {
+    margin-left: auto !important;
+}
+.mx-auto {
+    margin-left: auto !important;
+    margin-right: auto !important;
+}
+
 .p {
     @include spacing-modifiers($attribute: "padding");
 }


### PR DESCRIPTION
- fixes missing max height on modal content (never to exceed 80%)
- fixes a lobotomized owl selector clobbering footer items (not really needed)
- patches the util classes for margin to include `-auto` handling