### PR TITLE
MSAIL-1 badge rounded issue

### DIFF
--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -53,12 +53,12 @@ export const Badge = ({
     return (
         <span
             className={classify(
-                className,
                 "mainsail-badge",
                 color,
                 size,
                 variant,
-                isRounded ? "rounded" : "square"
+                isRounded ? "round" : "square",
+                className
             )}
             {...rest}>
             {variant !== ENUMS.variants.icon ? text : null}

--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -24,7 +24,7 @@
     &.sm {
         @include mainsail-body-text-small();
         font-weight: 700;
-        padding: 5px 7px;
+        padding: 3px 7px;
 
         svg {
             height: 12px;
@@ -115,7 +115,7 @@
         }
     }
 
-    &.rounded {
+    &.round {
         border-radius: 9999px;
 
         button {

--- a/src/components/Badge/Badge.stories.js
+++ b/src/components/Badge/Badge.stories.js
@@ -33,6 +33,13 @@ Basic.args = {
     variant: BadgeComponent.variants.basic,
 };
 
+export const Round = Badge.bind({});
+Round.args = {
+    text: "Badge",
+    isRounded: true,
+    variant: BadgeComponent.variants.basic,
+};
+
 export const Removable = Badge.bind({});
 Removable.args = {
     text: "Removable",

--- a/src/components/Badge/Badge.test.js
+++ b/src/components/Badge/Badge.test.js
@@ -5,11 +5,17 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/extend-expect";
 
-import { Basic, Removable } from "./Badge.stories";
+import { Basic, Round, Removable } from "./Badge.stories";
 
 it("renders the badge in the primary state", () => {
     render(<Basic {...Basic.args} />);
     expect(screen.getByText("Badge")).toBeInTheDocument();
+});
+
+it("renders the badge with the round style", () => {
+    render(<Round {...Round.args} />);
+    expect(screen.getByText("Badge")).toBeInTheDocument();
+    expect(screen.getByText("Badge").classList.contains("round")).toBe(true);
 });
 
 it("fires a provided onRemove handler", () => {


### PR DESCRIPTION
- fixes naming collision on rounded class
- tweaks height (padding) of `sm` size
- adds story for round badge along with simple test