### PR TITLE
fixes modal component applying css class to body

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -122,8 +122,11 @@ export const Modal = ({
             blurRef.classList.add("content-blur");
         }
 
-        // Always disable scroll on body
-        document.body.classList.add("overflow-hidden");
+        if (isOpen) {
+            document.body.classList.add("overflow-hidden");
+        } else if (!isOpen) {
+            document.body.classList.remove("overflow-hidden");
+        }
 
         // Cleanup added classes on unmount
         return () => {


### PR DESCRIPTION
This PR only addresses an issue where the Modal component would add an overflow hidden class to the document body when it shouldn't be.