### PR TITLE
Fix duplicate css injections

### DIFF
--- a/plop-templates/component-scss.hbs
+++ b/plop-templates/component-scss.hbs
@@ -1,3 +1,1 @@
-@import "../../styles/Variables.scss";
-
 /** {{componentName}} Component Styles */

--- a/plop-templates/component.hbs
+++ b/plop-templates/component.hbs
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 
-import "./{{componentName}}.scss";
 
 /**
 * Define and export enumerable prop values for use (then attach to component below)

--- a/src/components/AutoGrid/AutoGrid.js
+++ b/src/components/AutoGrid/AutoGrid.js
@@ -2,8 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 
-import "./AutoGrid.scss";
-
 export const flows = {
     row: "row",
     col: "col",

--- a/src/components/AutoGrid/AutoGrid.scss
+++ b/src/components/AutoGrid/AutoGrid.scss
@@ -1,6 +1,3 @@
-@import "../../styles/Variables.scss";
-@import "../../styles/Layout.scss";
-
 /** AutoGrid Component Styles */
 .mainsail-auto-grid {
     display: grid;

--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -3,8 +3,6 @@ import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 import { Icon } from "components/Icon/Icon";
 
-import "./Badge.scss";
-
 export const sizes = {
     sm: "sm",
     lg: "lg",

--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** Badge Component Styles */
 .mainsail-badge {
     display: inline-flex;

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -4,8 +4,6 @@ import { Icon } from "components/Icon";
 import { Spinner } from "components/Spinner";
 import { classify } from "utility/classify";
 
-import "./Button.scss";
-
 const renderIcon = (i, { side, size }) => {
     if (typeof i === "string") {
         return <Icon name={i} className={classify(side)} size={size} />;

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 button.mainsail-button {
     @include mainsail-button-text-regular();
     position: relative;

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -4,8 +4,6 @@ import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 import CheckIcon from "components/Icons/Check";
 
-import "./Checkbox.scss";
-
 export const colors = {
     blue: "blue",
     green: "green",

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -1,6 +1,3 @@
-@import "../../styles/Variables.scss";
-@import "../../styles/Layout.scss";
-
 /** Checkbox Component Styles */
 .mainsail-checkbox {
     @include mainsail-body-text-regular();

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -18,8 +18,6 @@ import {
     ESC_KEY_CODE,
 } from "utility/constants";
 
-import "./Dropdown.scss";
-
 export const placements = {
     auto: "auto",
     top: "top",

--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** Dropdown Component Styles */
 .mainsail-dropdown {
     @include mainsail-body-text-regular;

--- a/src/components/Flex/Flex.js
+++ b/src/components/Flex/Flex.js
@@ -2,8 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 
-import "./Flex.scss";
-
 export const alignItems = {
     flexStart: "flex-start",
     center: "center",

--- a/src/components/Flex/Flex.scss
+++ b/src/components/Flex/Flex.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-@import "../../styles/Layout.scss";
 // Adapted from https://github.com/rleija703/react-examples/blob/master/grid-component-with-typescript/
 
 /** Flex Component Styles */

--- a/src/components/FormControl/FormControl.js
+++ b/src/components/FormControl/FormControl.js
@@ -4,8 +4,6 @@ import { classify } from "utility/classify";
 import { useUniqueId } from "utility/hooks";
 import { isFragment } from "react-is";
 
-import "./FormControl.scss";
-
 /**
  *  This function cascades props down to immediate children for styling and functionality controlled by FormControl
  */

--- a/src/components/FormControl/FormControl.scss
+++ b/src/components/FormControl/FormControl.scss
@@ -1,6 +1,3 @@
-@import "../../styles/Variables.scss";
-@import "../../styles/Layout.scss";
-
 /** FormControl Component Styles */
 
 .mainsail-form-control {

--- a/src/components/FormHelpText/FormHelpText.js
+++ b/src/components/FormHelpText/FormHelpText.js
@@ -2,8 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 
-import "./FormHelpText.scss";
-
 /**
  * Define and export enumerable prop values for use (then attach to component below)
  * e.g. export const colors = {

--- a/src/components/FormHelpText/FormHelpText.scss
+++ b/src/components/FormHelpText/FormHelpText.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** FormHelpText Component Styles */
 .mainsail-help-text {
     box-sizing: border-box;

--- a/src/components/FormInputIcon/FormInputIcon.js
+++ b/src/components/FormInputIcon/FormInputIcon.js
@@ -3,8 +3,6 @@ import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 import { names, colors, Icon } from "components/Icon";
 
-import "./FormInputIcon.scss";
-
 /**
  * An icon that displays in a Form Input (for use as a child of FormControl)
  **/

--- a/src/components/FormInputIcon/FormInputIcon.scss
+++ b/src/components/FormInputIcon/FormInputIcon.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** FormInputIcon Component Styles */
 input.mainsail-input.with-icon {
     &:focus ~ .mainsail-icon.input-icon {

--- a/src/components/FormInputOptions/FormInputOptions.js
+++ b/src/components/FormInputOptions/FormInputOptions.js
@@ -3,8 +3,6 @@ import { isFragment } from "react-is";
 import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 
-import "./FormInputOptions.scss";
-
 /**
  * Attach input field options to a form control
  **/

--- a/src/components/FormInputOptions/FormInputOptions.scss
+++ b/src/components/FormInputOptions/FormInputOptions.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** FormInputOptions Component Styles */
 .mainsail-input-options {
     box-sizing: border-box;

--- a/src/components/FormLabel/FormLabel.js
+++ b/src/components/FormLabel/FormLabel.js
@@ -2,8 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 
-import "./FormLabel.scss";
-
 /**
  * @deprecated since version 7.0 - use directly attached ComponentName.<propNames>.value; e.g. Button.variants.secondary
  */

--- a/src/components/FormLabel/FormLabel.scss
+++ b/src/components/FormLabel/FormLabel.scss
@@ -1,6 +1,3 @@
-@import "../../styles/Variables.scss";
-@import "../../styles/Layout.scss";
-
 /** FormLabel Component Styles */
 
 label.mainsail-form-label {

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -3,8 +3,6 @@ import PropTypes from "prop-types";
 import * as MainsailIcon from "components/Icons";
 import { classify } from "utility/classify";
 
-import "./Icon.scss";
-
 const toFileCase = (str) =>
     str
         .split("_")
@@ -15,24 +13,24 @@ const toFileCase = (str) =>
         .join("");
 
 export const names = {
-	phone: "phone",
-	learn: "learn",
-	move_to: "move_to",
-	undo: "undo",
-	underline: "underline",
-	text_align_right: "text_align_right",
-	text_align_left: "text_align_left",
-	text_align_center: "text_align_center",
-	table: "table",
-	signature: "signature",
-	redo: "redo",
-	list_numbers: "list_numbers",
-	list_bullets: "list_bullets",
-	italic: "italic",
-	format_options: "format_options",
-	file: "file",
-	emoji: "emoji",
-	bold: "bold",
+    phone: "phone",
+    learn: "learn",
+    move_to: "move_to",
+    undo: "undo",
+    underline: "underline",
+    text_align_right: "text_align_right",
+    text_align_left: "text_align_left",
+    text_align_center: "text_align_center",
+    table: "table",
+    signature: "signature",
+    redo: "redo",
+    list_numbers: "list_numbers",
+    list_bullets: "list_bullets",
+    italic: "italic",
+    format_options: "format_options",
+    file: "file",
+    emoji: "emoji",
+    bold: "bold",
     preferences: "preferences",
     spreadsheet: "spreadsheet",
     unarchive: "unarchive",

--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 .mainsail-icon {
     color: $mainsail-blue-primary;
     display: inline-flex;

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -2,8 +2,6 @@ import React, { forwardRef } from "react";
 import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 
-import "./Input.scss";
-
 /**
  * @deprecated since version 7.0 - use directly attached ComponentName.<propNames>.value; e.g. Button.variants.secondary
  */

--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -1,6 +1,3 @@
-@import "../../styles/Variables.scss";
-@import "../../styles/Layout.scss";
-
 /** Input Component Styles */
 input[type="text"],
 input[type="tel"],

--- a/src/components/ListGroup/ListGroup.js
+++ b/src/components/ListGroup/ListGroup.js
@@ -5,8 +5,6 @@ import { useKeydown } from "utility/hooks";
 import { Icon } from "components/Icon";
 import { SPACE_KEY_CODES, ENTER_KEY_CODE } from "utility/constants";
 
-import "./ListGroup.scss";
-
 const renderIcon = (i) => {
     if (typeof i === "string") {
         return <Icon name={i} />;

--- a/src/components/ListGroup/ListGroup.scss
+++ b/src/components/ListGroup/ListGroup.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** ListGroup Component Styles */
 .mainsail-listgroup {
     display: flex;

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -13,8 +13,6 @@ import { convertFromResponsiveArray } from "utility/responsive";
 import { ESC_KEY_CODE, TAB_KEY_CODE } from "utility/constants";
 import { Transition } from "components/Transition";
 
-import "./Modal.scss";
-
 export const intents = {
     default: "default",
     danger: "danger",

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** Modal Component Styles */
 .mainsail-modal-container {
     z-index: 1000;

--- a/src/components/NativeDatePicker/NativeDatePicker.js
+++ b/src/components/NativeDatePicker/NativeDatePicker.js
@@ -3,8 +3,6 @@ import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 import { Icon } from "../Icon";
 
-import "./NativeDatePicker.scss";
-
 /**
  * Styles the default native/browser date input for a more consistent look (useful for Mobile)
  **/

--- a/src/components/NativeDatePicker/NativeDatePicker.scss
+++ b/src/components/NativeDatePicker/NativeDatePicker.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** DatePicker Component Styles */
 .mainsail-native-datepicker {
     position: relative;

--- a/src/components/PopMenu/PopMenu.js
+++ b/src/components/PopMenu/PopMenu.js
@@ -14,8 +14,6 @@ import {
 } from "utility/constants";
 import { Icon } from "components/Icon";
 
-import "./PopMenu.scss";
-
 export const variants = {
     borderless: "borderless",
 };

--- a/src/components/PopMenu/PopMenu.scss
+++ b/src/components/PopMenu/PopMenu.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** PopMenu Component Styles */
 .mainsail-pop-menu {
     * {

--- a/src/components/ProgressBar/ProgressBar.js
+++ b/src/components/ProgressBar/ProgressBar.js
@@ -2,8 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 
-import "./ProgressBar.scss";
-
 export const colors = {
     default: "default",
     dark: "dark",

--- a/src/components/ProgressBar/ProgressBar.scss
+++ b/src/components/ProgressBar/ProgressBar.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** ProgressBar Component Styles */
 .mainsail-progress {
     display: flex;

--- a/src/components/Radio/Radio.js
+++ b/src/components/Radio/Radio.js
@@ -3,8 +3,6 @@ import { isFragment } from "react-is";
 import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 
-import "./Radio.scss";
-
 export const colors = {
     blue: "blue",
     green: "green",

--- a/src/components/Radio/Radio.scss
+++ b/src/components/Radio/Radio.scss
@@ -1,6 +1,3 @@
-@import "../../styles/Variables.scss";
-@import "../../styles/Layout.scss";
-
 /** Radio Component Styles */
 .mainsail-radio {
     @include mainsail-body-text-regular();

--- a/src/components/SearchInput/SearchInput.js
+++ b/src/components/SearchInput/SearchInput.js
@@ -4,8 +4,6 @@ import { Icon } from "../Icon";
 import { Button } from "../Button";
 import { classify } from "utility/classify";
 
-import "./SearchInput.scss";
-
 /**
  * A styled search input with icons and support for clearing search terms (native props passed to input)
  **/

--- a/src/components/SearchInput/SearchInput.scss
+++ b/src/components/SearchInput/SearchInput.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** SearchInput Component Styles */
 .mainsail-search-input {
     position: relative;

--- a/src/components/Spinner/Spinner.js
+++ b/src/components/Spinner/Spinner.js
@@ -2,8 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 
-import "./Spinner.scss";
-
 export const colors = {
     default: "default",
     dark: "dark",

--- a/src/components/Spinner/Spinner.scss
+++ b/src/components/Spinner/Spinner.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /**
     Spinner Component Styles
     Adapted from https://github.com/tobiasahlin/SpinKit

--- a/src/components/Switcher/Switcher.js
+++ b/src/components/Switcher/Switcher.js
@@ -3,8 +3,6 @@ import PropTypes from "prop-types";
 import { Transition } from "components/Transition";
 import { classify } from "utility/classify";
 
-import "./Switcher.scss";
-
 export const useSwitcher = (config = {}) => {
     const [currentView, setCurrentView] = useState(1);
     const [prevView, setPrevView] = useState(1);

--- a/src/components/Switcher/Switcher.scss
+++ b/src/components/Switcher/Switcher.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** Switcher Component Styles */
 .mainsail-switcher {
     /* These properties are intended to be overridden by component props which utilize util classes */

--- a/src/components/Table/Actions.js
+++ b/src/components/Table/Actions.js
@@ -5,8 +5,6 @@ import { PopMenu } from "components/PopMenu";
 import { Icon } from "components/Icon";
 import { generateColumnWidthStyle } from "utility/responsive";
 
-import "./Table.scss";
-
 const alignments = {
     left: "left",
     center: "center",

--- a/src/components/Table/Column.js
+++ b/src/components/Table/Column.js
@@ -3,8 +3,6 @@ import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 import { generateColumnWidthStyle } from "utility/responsive";
 
-import "./Table.scss";
-
 const alignments = {
     left: "left",
     center: "center",

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -11,8 +11,6 @@ import { generateColumnWidthStyle } from "utility/responsive";
 import { ARIA_TRANSLATIONS } from "utility/constants";
 import { Checkbox } from "components/Checkbox";
 
-import "./Table.scss";
-
 export const variants = {
     bordered: "bordered",
     open: "open",

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** Table Component Styles */
 .mainsail-table {
     @include mainsail-body-text-regular;

--- a/src/components/Textarea/Textarea.js
+++ b/src/components/Textarea/Textarea.js
@@ -2,8 +2,6 @@ import React, { forwardRef } from "react";
 import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 
-import "./Textarea.scss";
-
 /**
  * @deprecated since version 7.0 - use directly attached ComponentName.<propNames>.value; e.g. Button.variants.secondary
  */

--- a/src/components/Textarea/Textarea.scss
+++ b/src/components/Textarea/Textarea.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** Textarea Component Styles */
 textarea.mainsail-textarea {
     @include mainsail-body-text-regular;

--- a/src/components/TimePicker/TimePicker.js
+++ b/src/components/TimePicker/TimePicker.js
@@ -3,8 +3,6 @@ import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 import { Dropdown } from "components/Dropdown";
 
-import "./TimePicker.scss";
-
 export const placements = {
     auto: "auto",
     top: "top",

--- a/src/components/TimePicker/TimePicker.scss
+++ b/src/components/TimePicker/TimePicker.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** TimePicker Component Styles */
 .mainsail-timepicker {
     display: flex;

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -3,8 +3,6 @@ import PropTypes from "prop-types";
 import { usePopper } from "react-popper";
 import { classify } from "utility/classify";
 
-import "./Tooltip.scss";
-
 const getOffset = (placement, offset = 8) => {
     let DIST = offset;
     const DEFAULT_OFFSET = [0, DIST];

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** Tooltip Component Styles */
 .mainsail-tooltip {
     @include mainsail-body-text-small();

--- a/src/components/Transition/Transition.js
+++ b/src/components/Transition/Transition.js
@@ -3,8 +3,6 @@ import PropTypes from "prop-types";
 import { classify } from "utility/classify";
 import { CSSTransition } from "react-transition-group";
 
-import "./Transition.scss";
-
 export const animations = {
     fade: "fade",
     fadeScale: "fade-scale",

--- a/src/components/Transition/Transition.scss
+++ b/src/components/Transition/Transition.scss
@@ -1,5 +1,3 @@
-@import "../../styles/Variables.scss";
-
 /** Transition Component Styles */
 
 .ms-fade-scale-enter,

--- a/src/components/core/index.js
+++ b/src/components/core/index.js
@@ -1,3 +1,6 @@
+// Entry point for all scss
+import "./index.scss";
+
 // Components Global Export for plopjs
 export { SearchInput } from "../SearchInput";
 export { ProgressBar } from "../ProgressBar";


### PR DESCRIPTION
In early efforts to allow for more advanced tree shaking, individual scss imports were used per component file. These additions accidentally resulted in duplicate imports of certain sass files. This duplication led to excess bundle size.

This PR reduces the final bundle by almost 300k by consolidating all scss to a single entry point.

Note: This also preps us for a possible future separation of css importing entirely (instead of injecting like we do now).