### PR TITLE
Unmount modal portals

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -143,12 +143,12 @@ export const Modal = ({
         };
     }, [isOpen, blurContentRef]);
 
-    useEffect(() => {
+    const handleInitialFocus = () => {
         if (isOpen && initialFocusRef) {
             initialFocusRef.current &&
                 initialFocusRef.current.focus({ preventScroll: true });
         }
-    }, [initialFocusRef, onCloseFocusRef, isOpen]);
+    };
 
     /**
      * We need to handle all dismisses
@@ -225,6 +225,9 @@ export const Modal = ({
                     shouldAnimateOnMount
                     animation={Transition.animations.fadeScale}
                     isActive={isOpen}
+                    onEntered={() => {
+                        handleInitialFocus();
+                    }}
                     onEnter={() => {
                         setOpenClass("open");
                     }}

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -66,6 +66,7 @@ export const Modal = ({
     const [openClass, setOpenClass] = useState(isOpen ? "open" : "");
     const modalId = useUniqueId("modal");
     const modalRef = useRef(null);
+    const [portalMounted, setPortalMounted] = useState(false);
 
     const breakpoint = useBreakpoint();
 
@@ -81,6 +82,13 @@ export const Modal = ({
         },
         [isOpen]
     );
+
+    // Handle mounting of portal on initial open
+    useEffect(() => {
+        if (isOpen) {
+            setPortalMounted(true);
+        }
+    }, [isOpen]);
 
     // Handle focus trap
     useKeydown((e) => {
@@ -163,6 +171,7 @@ export const Modal = ({
      */
     const handleOnClose = () => {
         setOpenClass("");
+        setPortalMounted(false);
         onClose && onClose();
 
         onCloseFocusRef &&
@@ -185,6 +194,10 @@ export const Modal = ({
 
         return styles;
     };
+
+    if (!portalMounted) {
+        return null;
+    }
 
     return (
         <WithPortal

--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -24,11 +24,41 @@ export default {
         },
     },
     parameters: {
+        docs: {
+            // opt-out of inline rendering
+            inlineStories: false,
+        },
         controls: { sort: "requiredFirst" },
     },
 };
 
 let setModalTemplateOpen;
+
+/**
+ * Simple Basic Modal Template
+ */
+const BasicTemplate = (args) => {
+    let [isOpen, setIsOpen] = useState(args.isOpen);
+
+    if (!isOpen) {
+        return <Button onClick={() => setIsOpen(true)} text="Open Modal" />;
+    }
+
+    return (
+        <Modal
+            {...args}
+            onConfirm={() => {
+                setIsOpen(false);
+                args.onConfirm && args.onConfirm();
+            }}
+            onCancel={() => {
+                setIsOpen(false);
+                args.onCancel && args.onCancel();
+            }}
+            isOpen={args.isOpen}
+        />
+    );
+};
 
 /**
  * Template is a state-ful wrapper around the Modal component
@@ -118,9 +148,8 @@ const Template = (args) => {
     );
 };
 
-export const BasicConfirm = (args) => <Modal {...args} />;
+export const BasicConfirm = BasicTemplate.bind({});
 BasicConfirm.args = {
-    isOpen: true,
     title: "Confirm",
     maxWidth: "600px",
     isDismissable: false,

--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -35,32 +35,6 @@ export default {
 let setModalTemplateOpen;
 
 /**
- * Simple Basic Modal Template
- */
-const BasicTemplate = (args) => {
-    let [isOpen, setIsOpen] = useState(args.isOpen);
-
-    if (!isOpen) {
-        return <Button onClick={() => setIsOpen(true)} text="Open Modal" />;
-    }
-
-    return (
-        <Modal
-            {...args}
-            onConfirm={() => {
-                setIsOpen(false);
-                args.onConfirm && args.onConfirm();
-            }}
-            onCancel={() => {
-                setIsOpen(false);
-                args.onCancel && args.onCancel();
-            }}
-            isOpen={args.isOpen}
-        />
-    );
-};
-
-/**
  * Template is a state-ful wrapper around the Modal component
  */
 const Template = (args) => {
@@ -148,8 +122,9 @@ const Template = (args) => {
     );
 };
 
-export const BasicConfirm = BasicTemplate.bind({});
+export const BasicConfirm = (args) => <Modal {...args} />;
 BasicConfirm.args = {
+    isOpen: true,
     title: "Confirm",
     maxWidth: "600px",
     isDismissable: false,

--- a/src/components/Modal/Modal.test.js
+++ b/src/components/Modal/Modal.test.js
@@ -221,7 +221,11 @@ it("will handle focus on elements when opened and closed", async () => {
 
     expect(screen.queryByRole("dialog")).toBeInTheDocument();
 
-    expect(screen.getByRole("textbox", { name: "Modal Input" })).toHaveFocus();
+    await waitFor(() => {
+        expect(
+            screen.getByRole("textbox", { name: "Modal Input" })
+        ).toHaveFocus();
+    });
 
     userEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
@@ -240,8 +244,11 @@ it("will trap focus on elements when opened", async () => {
 
     expect(screen.queryByRole("dialog")).toBeInTheDocument();
 
-    expect(screen.getByRole("textbox", { name: "Modal Input" })).toHaveFocus();
-
+    await waitFor(() => {
+        expect(
+            screen.getByRole("textbox", { name: "Modal Input" })
+        ).toHaveFocus();
+    });
     userEvent.tab();
 
     expect(screen.getByRole("button", { name: "Cancel" })).toHaveFocus();

--- a/src/styles/Layout.scss
+++ b/src/styles/Layout.scss
@@ -382,6 +382,23 @@
     .flex-shrink {
         flex-shrink: 1;
     }
+
+    .flex-1,
+    &.flex-1 {
+        flex: 1;
+    }
+    .flex-2,
+    &.flex-2 {
+        flex: 1;
+    }
+    .flex-3,
+    &.flex-3 {
+        flex: 1;
+    }
+    .flex-4,
+    &.flex-4 {
+        flex: 4;
+    }
 }
 
 .relative {


### PR DESCRIPTION
This PR unmounts the portal'd modal container from the dom when the modal closes out (animation is finished).

This negates the need to handle this at implementation sites. 