### PR TITLE
Add Associations Icon in React

### DIFF
--- a/src/components/Icons/ArrowsLeftRight.js
+++ b/src/components/Icons/ArrowsLeftRight.js
@@ -1,0 +1,31 @@
+import * as React from "react";
+const SvgArrowsLeftRight = (props) => (
+    <svg
+        width="1em"
+        height="1em"
+        viewBox="0 0 32 32"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        {...props}>
+        <g
+            clip-path="url(#a)"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2">
+                <path
+                    d="m22 18 4 4-4 4"
+                />
+                <path
+                    d="m6 22h20"
+                />
+                <path
+                    d="m10 14-4-4 4-4"
+                />
+                <path
+                    d="M26 10H6"
+                />
+        </g>
+    </svg>
+);
+export default SvgArrowsLeftRight;

--- a/src/components/Icons/ArrowsLeftRight.js
+++ b/src/components/Icons/ArrowsLeftRight.js
@@ -8,11 +8,11 @@ const SvgArrowsLeftRight = (props) => (
         xmlns="http://www.w3.org/2000/svg"
         {...props}>
         <g
-            clip-path="url(#a)"
+            clipPath="url(#a)"
             stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2">
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2">
                 <path
                     d="m22 18 4 4-4 4"
                 />


### PR DESCRIPTION
This should unblock BRZE-619, adding the `ArrowLeftRight` icon for use on the associations button in react.

TESTING:

- Log in to org as account owner
- Navigate to: /r/payments/methods
- There should be an icon next to the "Associations" button at the bottom of the side nav